### PR TITLE
fix: add vite-runtime-files to docker images

### DIFF
--- a/projects/rust/fullstack-rustapp-template/workspace.nix
+++ b/projects/rust/fullstack-rustapp-template/workspace.nix
@@ -152,6 +152,9 @@
       dockerImage = pkgs.dockerTools.streamLayeredImage {
         name = "fullstack-rustapp-server";
         tag = "latest";
+                contents = [
+                    vite-runtime-files
+                ];
         config = {
           Cmd = ["${server}/bin/server"];
           Env = ["VITE_MANIFEST_PATH=${vite-manifests}/manifest/manifest.json"];
@@ -161,6 +164,9 @@
       dockerDevImage = pkgs.dockerTools.streamLayeredImage {
         name = "fullstack-rustapp-server";
         tag = "latest";
+        contents = [
+            vite-runtime-files
+        ];
         config = {
           Cmd = ["${devServer}/bin/server"];
           Env = ["VITE_MANIFEST_PATH=${vite-manifests}/manifest/manifest.json"];

--- a/projects/rust/fullstack-rustapp-template/workspace.nix
+++ b/projects/rust/fullstack-rustapp-template/workspace.nix
@@ -152,9 +152,9 @@
       dockerImage = pkgs.dockerTools.streamLayeredImage {
         name = "fullstack-rustapp-server";
         tag = "latest";
-                contents = [
-                    vite-runtime-files
-                ];
+        contents = [
+          vite-runtime-files
+        ];
         config = {
           Cmd = ["${server}/bin/server"];
           Env = ["VITE_MANIFEST_PATH=${vite-manifests}/manifest/manifest.json"];
@@ -165,7 +165,7 @@
         name = "fullstack-rustapp-server";
         tag = "latest";
         contents = [
-            vite-runtime-files
+          vite-runtime-files
         ];
         config = {
           Cmd = ["${devServer}/bin/server"];


### PR DESCRIPTION
Fixes missing vite runtime files caused by #34 